### PR TITLE
Copy buffer from old instance on new one

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,15 @@ var websocket = require('websocket-stream');
 var inject = require('reconnect-core');
 
 module.exports = inject(function () {
+  // Create new websocket-stream instance
   var args = [].slice.call(arguments);
-  return websocket.apply(null, args);
+  var ws = websocket.apply(null, args);
+
+  // Copy buffer from old websocket-stream instance on the new one
+  if(this.prevCon)
+    ws._buffer = this.prevCon._buffer;
+  this.prevCon = ws;
+
+  // Return new websocket-stream instance
+  return ws;
 });

--- a/index.js
+++ b/index.js
@@ -7,8 +7,9 @@ module.exports = inject(function () {
   var ws = websocket.apply(null, args);
 
   // Copy buffer from old websocket-stream instance on the new one
-  if(this.prevCon)
-    ws._buffer = this.prevCon._buffer;
+  var prevCon = this.prevCon;
+  if(prevCon && prevCon._buffer)
+    ws._buffer = prevCon._buffer;
   this.prevCon = ws;
 
   // Return new websocket-stream instance

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "homepage": "https://github.com/jacobbubu/reconnect-ws",
   "dependencies": {
-    "reconnect-core": "0.0.1",
-    "websocket-stream": "~0.5.0"
+    "reconnect-core": "0.1.0",
+    "websocket-stream": "~0.5.1"
   },
   "devDependencies": {
     "ws": "~0.4.31"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/jacobbubu/reconnect-ws",
   "dependencies": {
-    "reconnect-core": "^0.2.0",
+    "reconnect-core": "KurentoForks/reconnect-core",
     "websocket-stream": "~0.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "websocket-stream": "~0.5.1"
   },
   "devDependencies": {
-    "ws": "~0.4.31"
+    "ws": "~1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/jacobbubu/reconnect-ws",
   "dependencies": {
-    "reconnect-core": "0.0.1",
+    "reconnect-core": "^0.2.0",
     "websocket-stream": "~0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Allow to don't miss any message while swapping the websocket-stream instances in a transparent way for the user.
