### PR TITLE
Update version of reconnect-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/jacobbubu/reconnect-ws",
   "dependencies": {
-    "reconnect-core": "0.0.1",
+    "reconnect-core": "^0.2.0",
     "websocket-stream": "~0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
reconnect-core v0.2.0 added support to notify user if it was fetched an user-defined max number of retries. Also, the `^` syntax allow to use that version and newer ones, and it's recomended to use it for libraries instead of fixed versions.
